### PR TITLE
Adding DI for IConnectionMultiplexer for Redis in the OrderProcessing module

### DIFF
--- a/src/RiverBooks.OrderProcessing/Endpoints/FlushCache.cs
+++ b/src/RiverBooks.OrderProcessing/Endpoints/FlushCache.cs
@@ -14,11 +14,9 @@ internal class FlushCache : EndpointWithoutRequest
   private readonly IDatabase _db;
   private readonly ILogger<FlushCache> _logger;
 
-  public FlushCache(ILogger<FlushCache> logger)
-  {
-    // TODO: use DI
-    var redis = ConnectionMultiplexer.Connect("localhost"); // TODO: Get server from config
-    _db = redis.GetDatabase();
+  public FlushCache(ILogger<FlushCache> logger, IConnectionMultiplexer connectionMultiplexer)
+  {    
+    _db = connectionMultiplexer.GetDatabase();
     _logger = logger;
   }
 

--- a/src/RiverBooks.OrderProcessing/Infrastructure/RedisOrderAddressCache.cs
+++ b/src/RiverBooks.OrderProcessing/Infrastructure/RedisOrderAddressCache.cs
@@ -12,10 +12,9 @@ internal class RedisOrderAddressCache : IOrderAddressCache
   private readonly IDatabase _db;
   private readonly ILogger<RedisOrderAddressCache> _logger;
 
-  public RedisOrderAddressCache(ILogger<RedisOrderAddressCache> logger)
-  {
-    var redis = ConnectionMultiplexer.Connect("localhost"); // TODO: Get server from config
-    _db = redis.GetDatabase();
+  public RedisOrderAddressCache(ILogger<RedisOrderAddressCache> logger, IConnectionMultiplexer connectionMultiplexer)
+  {    
+    _db = connectionMultiplexer.GetDatabase();
     _logger = logger;
   }
 

--- a/src/RiverBooks.OrderProcessing/OrderProcessingModuleServicesExtensions.cs
+++ b/src/RiverBooks.OrderProcessing/OrderProcessingModuleServicesExtensions.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using RiverBooks.OrderProcessing.Infrastructure;
 using RiverBooks.OrderProcessing.Infrastructure.Data;
 using RiverBooks.OrderProcessing.Interfaces;
 using Serilog;
+using StackExchange.Redis;
 
 namespace RiverBooks.Users;
 
@@ -22,6 +24,11 @@ public static class OrderProcessingModuleServicesExtensions
     services.AddScoped<IOrderRepository, EfOrderRepository>();
     services.AddScoped<RedisOrderAddressCache>();
     services.AddScoped<IOrderAddressCache, ReadThroughOrderAddressCache>();
+
+    services.AddSingleton<IConnectionMultiplexer>(sp =>
+    {
+      return ConnectionMultiplexer.Connect(config.GetSection("Redis").GetValue<string>("ConnectionString"));
+    });
 
     // if using MediatR in this module, add any assemblies that contain handlers to the list
     mediatRAssemblies.Add(typeof(OrderProcessingModuleServicesExtensions).Assembly);

--- a/src/RiverBooks.Web/appsettings.json
+++ b/src/RiverBooks.Web/appsettings.json
@@ -43,5 +43,8 @@
   "MongoDB": {
     "ConnectionString": "mongodb://localhost:27017",
     "DatabaseName": "RiverBooksEmail"
+  },
+  "Redis": {
+    "ConnectionString": "localhost:6379,abortConnect=false"
   }
 }


### PR DESCRIPTION
- Moving the IConnectionMultiplexer setup to the OrderProcessingModuleServicesExtensions
- Adding a section to appsettings.json for the Redis connection string