### PR TITLE
test: add coverage for FluentValidationBehavior.Handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 /src/.idea/.idea.RiverBooks/.idea
+coverage/

--- a/src/RiverBooks.SharedKernel.Tests/FluentValidationBehavior_ValidationFails.cs
+++ b/src/RiverBooks.SharedKernel.Tests/FluentValidationBehavior_ValidationFails.cs
@@ -1,0 +1,53 @@
+using System.Runtime.CompilerServices;
+using Ardalis.Result;
+using FluentValidation;
+using FluentValidation.Results;
+using Mediator;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+// FluentValidation is strong-named, so NSubstitute's Castle-based proxy generator needs an
+// explicit grant to create a substitute for IValidator<CreateWidgetCommand> when
+// CreateWidgetCommand is `internal` rather than `public`.
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+
+namespace RiverBooks.SharedKernel.Tests;
+
+public class FluentValidationBehavior_ValidationFails
+{
+  [Fact]
+  public async Task ReturnsInvalidResultWithErrors()
+  {
+    // Arrange
+    var request = CreateWidgetFixtures.MakeCommand(name: "");
+
+    var validator = Substitute.For<IValidator<CreateWidgetCommand>>();
+    validator.ValidateAsync(Arg.Any<ValidationContext<CreateWidgetCommand>>(), Arg.Any<CancellationToken>())
+      .Returns(new ValidationResult(new[]
+      {
+        new ValidationFailure("Name", "Name is required.")
+      }));
+
+    var behavior = new FluentValidationBehavior<CreateWidgetCommand, Result<string>>(new[] { validator });
+
+    var next = Substitute.For<MessageHandlerDelegate<CreateWidgetCommand, Result<string>>>();
+    next(Arg.Any<CreateWidgetCommand>(), Arg.Any<CancellationToken>())
+      .Returns(new ValueTask<Result<string>>(Result<string>.Success("should-not-be-reached")));
+
+    // Act
+    var result = await behavior.Handle(request, next, CancellationToken.None);
+
+    // Assert
+    result.Status.ShouldBe(ResultStatus.Invalid);
+    result.ValidationErrors.ShouldContain(e => e.ErrorMessage == "Name is required.");
+    _ = next.DidNotReceive()(Arg.Any<CreateWidgetCommand>(), Arg.Any<CancellationToken>());
+  }
+}
+
+internal record CreateWidgetCommand(string Name) : IRequest<Result<string>>;
+
+internal static class CreateWidgetFixtures
+{
+  public static CreateWidgetCommand MakeCommand(string name = "Widget") => new(name);
+}

--- a/src/RiverBooks.SharedKernel.Tests/FluentValidationBehavior_ValidationPasses.cs
+++ b/src/RiverBooks.SharedKernel.Tests/FluentValidationBehavior_ValidationPasses.cs
@@ -1,0 +1,37 @@
+using Ardalis.Result;
+using FluentValidation;
+using FluentValidation.Results;
+using Mediator;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace RiverBooks.SharedKernel.Tests;
+
+public class FluentValidationBehavior_ValidationPasses
+{
+  [Fact]
+  public async Task CallsNextAndReturnsItsResult()
+  {
+    // Arrange
+    var request = CreateWidgetFixtures.MakeCommand(name: "Widget");
+
+    var validator = Substitute.For<IValidator<CreateWidgetCommand>>();
+    validator.ValidateAsync(Arg.Any<ValidationContext<CreateWidgetCommand>>(), Arg.Any<CancellationToken>())
+      .Returns(new ValidationResult());
+
+    var behavior = new FluentValidationBehavior<CreateWidgetCommand, Result<string>>(new[] { validator });
+
+    var next = Substitute.For<MessageHandlerDelegate<CreateWidgetCommand, Result<string>>>();
+    next(Arg.Any<CreateWidgetCommand>(), Arg.Any<CancellationToken>())
+      .Returns(new ValueTask<Result<string>>(Result<string>.Success("widget-created")));
+
+    // Act
+    var result = await behavior.Handle(request, next, CancellationToken.None);
+
+    // Assert
+    _ = next.Received(1)(Arg.Any<CreateWidgetCommand>(), Arg.Any<CancellationToken>());
+    result.Status.ShouldBe(ResultStatus.Ok);
+    result.Value.ShouldBe("widget-created");
+  }
+}

--- a/src/RiverBooks.SharedKernel.Tests/RiverBooks.SharedKernel.Tests.csproj
+++ b/src/RiverBooks.SharedKernel.Tests/RiverBooks.SharedKernel.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Module>SharedKernel</Module>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RiverBooks.SharedKernel\RiverBooks.SharedKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RiverBooks.slnx
+++ b/src/RiverBooks.slnx
@@ -26,5 +26,6 @@
   <Project Path="RiverBooks.AppHost/RiverBooks.AppHost.csproj" />
   <Project Path="RiverBooks.ServiceDefaults/RiverBooks.ServiceDefaults.csproj" />
   <Project Path="RiverBooks.SharedKernel/RiverBooks.SharedKernel.csproj" />
+  <Project Path="RiverBooks.SharedKernel.Tests/RiverBooks.SharedKernel.Tests.csproj" />
   <Project Path="RiverBooks.Web/RiverBooks.Web.csproj" />
 </Solution>


### PR DESCRIPTION
## What

Added tests for `FluentValidationBehavior<TRequest, TResponse>.Handle`, which had a CRAP score of 342 (cyclomatic complexity 18) with 0% line coverage.

## Coverage gap addressed

- **Class**: `RiverBooks.SharedKernel.FluentValidationBehavior<TRequest, TResponse>`
- **Method**: `ValueTask<TResponse> Handle(TRequest request, MessageHandlerDelegate<TRequest, TResponse> next, CancellationToken cancellationToken)`
- **CRAP score before**: 342

This is a cross-cutting MediatR pipeline behavior registered globally, executing on every command/query dispatched through the application. It contains reflection-based branching to decide how to surface validation failures depending on `TResponse`'s shape. The new tests cover the `Result<T>` branch: the reflection-based `Result<T>.Invalid(...)` path taken on validation failure, and the pass-through-to-`next` happy path.

A new `RiverBooks.SharedKernel.Tests` project was added to the solution to host these tests.

## Mutation validation

The test was validated by applying a breaking mutation (`failures.Count != 0` → `failures.Count == 0`) to `FluentValidationBehavior.Handle` and confirming the failure-path test caught it (asserted `ResultStatus.Invalid`, mutation produced `ResultStatus.Ok`). The mutation was reverted after confirmation.

## Test plan

- [ ] `dotnet test src/RiverBooks.slnx --filter "FullyQualifiedName~FluentValidationBehavior"` passes green (2/2)
- [ ] Review the tests for intent clarity